### PR TITLE
importers: uncommented download_all() line in generate_csv.py in toil…

### DIFF
--- a/importers/toiletmap.gov.au/generate_csv.py
+++ b/importers/toiletmap.gov.au/generate_csv.py
@@ -102,6 +102,6 @@ def generate_csv():
 
 if __name__ == '__main__':
 	print 'Downloading...'
-	#download_all(True, True)
+	download_all(True, True)
 	print 'Generating CSV...'
         generate_csv()


### PR DESCRIPTION
…etmap.gov.au

Uncommented the download_all() line so if anyone runs "python generate_csv.py", it'll try downloading the necessary files first.

Related to issue-8