### PR TITLE
app: fixed data seed order

### DIFF
--- a/app/database/seeds/DatabaseSeeder.php
+++ b/app/database/seeds/DatabaseSeeder.php
@@ -27,8 +27,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-		$tables_to_seed_using_json = ['role', 'building', 'building_group',
-			'building_tag', 'building_building_tag', 'question',
+		$tables_to_seed_using_json = ['role', 'building_building_tag', 'building',
+			'building_group', 'building_tag', 'question',
 			'question_category', 'country'];
 		foreach ($tables_to_seed_using_json as $table_name) {
 			DB::table($table_name)->delete();


### PR DESCRIPTION
Fixed order of tables in DatabaseSeeder.php so it would work with MariaDb.
The tables were out of order leading to a foreign key constraint violation
when building_building_tag data was inserted before the building and
building_tag data that it needed to reference.