### PR TITLE
app: fixed broken link to login from the signup success view

### DIFF
--- a/app/resources/views/pages/signup/success.blade.php
+++ b/app/resources/views/pages/signup/success.blade.php
@@ -4,7 +4,7 @@
 	<h1>Sign Up</h1>
 	<div class="text-center success">
 		<strong>Your account has been created.</strong>
-		<p>You can <a href="/login?email={{ $email }}">log in</a> with it now.</p>
+		<p>You can <a href="/signin?email={{ $email }}">log in</a> with it now.</p>
 	</div>
 </div>
 


### PR DESCRIPTION
Related to a rename of login to signin that happened a week ago