### PR TITLE
app: made the sortability of columns more visible to users using unde…

### DIFF
--- a/app/resources/assets/sass/app.scss
+++ b/app/resources/assets/sass/app.scss
@@ -48,6 +48,11 @@ $base_colour1: #153157;
 	}
 }
 
+%sorted-column-title {
+	text-decoration: none;
+	color: #000;
+}
+
 @mixin social-media-large-button($colour) {
 	background-color: $colour;
 	border-color: $colour;
@@ -126,12 +131,33 @@ h1, h2, h3 {
 	}
 }
 
+.spreadsheet.sort-by-name .column-titles .name a {
+	@extend %sorted-column-title;
+}
+
+.spreadsheet.sort-by-rating .column-titles .accessibility-rating a {
+	@extend %sorted-column-title;
+}
+
+.spreadsheet.sort-by-distance .column-titles .distance a {
+	@extend %sorted-column-title;
+}
+
 .spreadsheet {
 	h3 {
 		margin-top: 5px;
 
 		> a {
 			color: #000;
+		}
+	}
+	
+	.column-titles a {
+		text-decoration: underline;
+		transition: color 0.3s;
+		
+		&:hover {
+			color: #029;
 		}
 	}
 	

--- a/app/resources/views/pages/location_search/spreadsheet.blade.php
+++ b/app/resources/views/pages/location_search/spreadsheet.blade.php
@@ -2,14 +2,14 @@
 	@if (count($locations) === 0)
 		No location found matching the specified keywords
 	@else
-		<div class="row">
-			<div class="col-xs-6">
+		<div class="row column-titles">
+			<div class="col-xs-6 name">
 				<h3><a href="{{ $url_factory->createURLForOrderByField('name') }}">Name</a></h3>
 			</div>
-			<div class="col-xs-3">
+			<div class="col-xs-3 accessibility-rating">
 				<h3><a href="{{ $url_factory->createURLForOrderByField('rating') }}">Accessibility Rating (%)</a></h3>
 			</div>
-			<div class="col-xs-3">
+			<div class="col-xs-3 distance">
 				<h3><a href="{{ $url_factory->createURLForOrderByField('distance') }}">Distance (km)</a></h3>
 			</div>
 		</div>


### PR DESCRIPTION
…rlining and colour

This was based on a comment from Stephanos:
"
What I would recommend thought is to highlight (change
color) the column title that is sorted, by default is NAME and perhaps
underline the other 2 columns indicating that those are links as well. As
it is right now, users might not understand that these are actually links
that can sort the columns.
"

Related to #135