### PR TITLE
UserTableSeeder.php: fixed bug where the hashed passwords were not be…

### DIFF
--- a/app/database/seeds/UserTableSeeder.php
+++ b/app/database/seeds/UserTableSeeder.php
@@ -13,7 +13,7 @@ class UserTableSeeder extends Seeder
 		$users = SeedHelper::readTableData('user.json');
 		$user_roles = [];
 		// set passwords.
-		foreach ($users as $user)
+		foreach ($users as &$user)
 		{
 			$user['password_hash'] = User::generateSaltedHash('password');
 			$user_roles []= [


### PR DESCRIPTION
…ing set

The way the foreach loop was working before, the $user was referring to a
copy.  Setting the 'hashed_password' on it was being ignored.  This commit
fixes that mistake.