### PR TITLE
app scss: removed mistakenly added underlining to social media buttons

### DIFF
--- a/app/resources/assets/sass/_social_media_buttons.scss
+++ b/app/resources/assets/sass/_social_media_buttons.scss
@@ -5,10 +5,6 @@
 	padding-bottom: 70px;
 	padding-left: 80px;
 	border-left: 1px solid #bbb;
-
-	&:hover > a > i {
-		text-decoration: none;
-	}
 	
 	> a {
 		display: flex;
@@ -17,6 +13,10 @@
 		padding-top: 1px;
 		margin-top: 25px;
 		border-radius: 3px;
+
+		&:hover {
+			text-decoration: none;
+		}
 		
 		> i {
 			flex-grow: 0;


### PR DESCRIPTION
This fixes some changes that unintentionally lead to underlining while
hovering over social media buttons.

This is likely related to pull request #412.