### PR TITLE
app: removed Remember Me checkbox because it isn't working

### DIFF
--- a/app/resources/assets/sass/_sign_in.scss
+++ b/app/resources/assets/sass/_sign_in.scss
@@ -26,10 +26,6 @@
 
 	.remember-password {
 		padding-top: 10px;
-
-		label {
-			font-weight: 100;
-		}
 	}
 }
 

--- a/app/resources/views/pages/signin.blade.php
+++ b/app/resources/views/pages/signin.blade.php
@@ -30,9 +30,6 @@
 						
                         <div class="col-xs-12">
 							<div class="remember-password">
-								<label>
-									<input type="checkbox"> Remember Me
-								</label>
 								<a class="pull-right" href="/password-recovery"> Forgot Password? </a>
 							</div>
                         </div>


### PR DESCRIPTION
Until someone completes #383 with a working Remember Me feature or has
some other reasonable purpose behind it, the checkbox is just confusing.
The checkbox was part of an incomplete feature and incomplete features
tend to confuse people who test the application.  It also requires effort
to communicate that we know it is incomplete.  Removing incomplete
features seems better for now.

Related to #383.