### PR TITLE
app: enforced maximum search radius in profile

### DIFF
--- a/app/app/Http/Controllers/ProfileController.php
+++ b/app/app/Http/Controllers/ProfileController.php
@@ -46,7 +46,8 @@ class ProfileController extends Controller {
 			'num_reviews' => count(AnswerRepository::getReviewedLocations()['location_ids']),
 			'num_locations_added_by_me' => $num_locations_added_by_me,
 			'is_internal_user' => BaseUser::isInternal(),
-			'enabled_country_ids' => $enabled_country_ids
+			'enabled_country_ids' => $enabled_country_ids,
+			'max_search_radius_km' => BaseUser::getMaximumSearchRadiusKM()
 			];
 
 		if ($validator === null)
@@ -88,10 +89,12 @@ class ProfileController extends Controller {
 		$user->first_name = $request->first_name;
 		$user->last_name = $request->last_name;
 		$user->location_search_text = $request->location_search_text;
-		if ( $request->search_radius_km === '' )
+		if ( !is_numeric($request->search_radius_km) )
 			$user->search_radius_km = null;
-		else
-			$user->search_radius_km = floatval(trim($request->search_radius_km));
+		else {
+			// Sanitize to within the valid range.
+			$user->search_radius_km = max(0.01, min(floatval(trim($request->search_radius_km)), BaseUser::getMaximumSearchRadiusKM()));
+		}
 		$user->uses_screen_reader = isset($request->uses_screen_reader) ? 1 : 0;
 
 		$current_user_questions = $user->requiredQuestions()->get();

--- a/app/resources/views/pages/profile/profile.blade.php
+++ b/app/resources/views/pages/profile/profile.blade.php
@@ -158,7 +158,7 @@
 								type="number"
 								step="0.01"
 								min="0.01"
-								max="20040"
+								max="{{ $max_search_radius_km }}"
 								value="{{ $user->search_radius_km }}">
 						</div>
 					</div>


### PR DESCRIPTION
The maximum search radius was enforced for the location search feature in
both Table and Map mode through the radius save API but the profile still
allowed a larger radius to be saved.  This commit fixes the inconsistency.

Related to work in #373