### PR TITLE
gitignore: ignored files in public/fonts/bootstrap

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /public/storage
 /storage/*.key
+/public/fonts/bootstrap/*
 /public/css/app.css
 /public/js/app.js
 /public/css/app.css.map


### PR DESCRIPTION
The files in public/fonts/bootstrap are generated every time 'gulp' is
run.  We don't want output files tracked for the same reasons we
wouldn't want compiled files tracked.