### PR TITLE
app: removed an unused svg image and associated SCSS

### DIFF
--- a/app/public/images/drop-down-arrow.svg
+++ b/app/public/images/drop-down-arrow.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="255px" height="255px" viewBox="0 0 255 255" style="enable-background:new 0 0 255 255;" xml:space="preserve">
-	<g id="arrow-drop-down">
-		<polygon points="0,0 127.5,255 255,0" style="fill: #565656" />
-	</g>
-</svg>

--- a/app/resources/assets/sass/_profile.scss
+++ b/app/resources/assets/sass/_profile.scss
@@ -1,12 +1,5 @@
 @import "_placeholders.scss";
 
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    /* IE10+ styles */
-	div.profile select.form-control {
-		background-image: none;
-	}
-}
-
 .profile {
 	@extend %page-base;
 
@@ -53,18 +46,6 @@
 	select {
 		option[disabled] {
 			display: none;
-		}
-
-		&.form-control {
-			-webkit-appearance: none;
-			-moz-appearance: none;
-			background-image: url('/images/drop-down-arrow.svg');
-			background-position: right 16px top 12px;
-			background-size: 9px 8px;
-			background-repeat: no-repeat;
-			background-color: #fff;
-			appearance: none;
-			box-shadow: 0 0 7px #fff inset, 0 0 7px #fff inset, 0 0 7px #fff inset;
 		}
 	}
 


### PR DESCRIPTION
This commit essentially reverts pull request #508.

The changes are being undone because the arrow image is no longer needed
after some changes from Hardik for #523 turned the input into a select.
A select arrow is naturally much more consistent with the country's
select element.

Related to #315 and #523