### PR TITLE
app: utils: fixed problems in update_rating_cache.py

### DIFF
--- a/importers/utils/import_helpers/rating_cache_task_loader.py
+++ b/importers/utils/import_helpers/rating_cache_task_loader.py
@@ -27,15 +27,21 @@ def get_task_info():
 	site_url = 'localhost:8000'
 	env_data = env_loader.get_env_data()
 
-	if len(sys.argv) < 2:
-		if 'APP_URL' in env_data:
-			site_url = env_data['APP_URL']
-			print ('Using APP_URL from .env file: ' + site_url)
-		else:
-			print ('site_url should be specified.  Defaulting to: ' + site_url)
+	my_args = sys.argv[1:]
+	is_resetting_cache = '--reset' in my_args
+	my_args = list(set(my_args) - set(['--reset']))
+
+	if len(my_args) < 1:
+			if 'APP_URL' in env_data:
+					site_url = env_data['APP_URL']
+					print ('Using APP_URL from .env file: ' + site_url)
+			else:
+					print ('site_url should be specified.  Defaulting to: ' + site_url)
+	else:
+		site_url = my_args[0]
 
 	site_url = sanitize_site_url(site_url)
-	is_resetting_cache = '--reset' in sys.argv
+
 	if is_resetting_cache and not is_local(site_url, env_data):
 		raise ValueError('Can not clear cache for remote site\'s database')
 

--- a/importers/utils/update_rating_cache.py
+++ b/importers/utils/update_rating_cache.py
@@ -5,6 +5,7 @@ import sys
 import time
 import import_helpers.rating_cache_task_loader as rating_cache_task_loader
 import MySQLdb
+import json
 
 
 def get_db_connection(connection_settings):
@@ -62,6 +63,7 @@ def populate_ratings_cache(site_url):
 
 if __name__ == '__main__':
 	task_info = rating_cache_task_loader.get_task_info()
+	print('Task info = ' + json.dumps(task_info, sort_keys=True, indent=4))
 	if task_info['is_resetting_cache']:
 		clear_cache(task_info)
 	populate_ratings_cache(task_info['site_url'])


### PR DESCRIPTION
These problems included:
- APP_URL in .env file was being ignored.
- site_url specified in command line arguments was being ignored.
- Logic around using .env file's APP_URL was incorrect since it didn't
consider that --reset could be one of the arguments and affect the
length.

Related to #555