### PR TITLE
app: removed redundant public/fonts reference from .gitignore

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -14,4 +14,3 @@ composer.lock
 Homestead.json
 Homestead.yaml
 .env
-/public/fonts


### PR DESCRIPTION
The public/fonts reference was redundant because another reference meets
the same need with public/fonts/bootstrap.

Done to clean up some technical debt added to a pull request #580 on issue #269.