### PR TITLE
app: fixed PHPUnit tests after some recent changes broke them

### DIFF
--- a/app/tests/LocationSearchRadiusTest.php
+++ b/app/tests/LocationSearchRadiusTest.php
@@ -13,7 +13,7 @@ class LocationSearchRadiusTest extends TestCase
         $testCase->assertTrue(isset($response_data->message));
 
         // Check that the radius was set.
-        $response = $testCase->get('/location/search?location_tag_id=1');
+        $response = $testCase->get('/location/search?location_tag_id=1&view=table');
         $testCase->assertEquals(200, $response->getStatusCode());
         $search_content = $response->getContent();
         $pos = strpos($search_content, 'placeholder="distance" value="'.$testDistance.'"');

--- a/app/tests/LocationSearchTest.php
+++ b/app/tests/LocationSearchTest.php
@@ -12,7 +12,7 @@ class LocationSearchTest extends TestCase
     
     public function testSortByName()
     {
-        $response = $this->get('/location/search?location_tag_id=1&keywords=&order_by=name');
+        $response = $this->get('/location/search?location_tag_id=1&keywords=&order_by=name&view=table');
         $this->assertEquals(200, $response->getStatusCode());
         $content = $response->getContent();
         $this->assertTrue(strpos($content, 'spreadsheet sort-by-name') !== false);
@@ -21,7 +21,7 @@ class LocationSearchTest extends TestCase
 
     public function testSortByDistance()
     {
-        $response = $this->get('/location/search?location_tag_id=1&keywords=&order_by=distance');
+        $response = $this->get('/location/search?location_tag_id=1&keywords=&order_by=distance&view=table');
         $this->assertEquals(200, $response->getStatusCode());
         $content = $response->getContent();
         $this->assertTrue(strpos($content, 'spreadsheet sort-by-distance') !== false);
@@ -30,7 +30,7 @@ class LocationSearchTest extends TestCase
 
     public function testSortByRating()
     {
-        $response = $this->get('/location/search?location_tag_id=1&keywords=&order_by=rating');
+        $response = $this->get('/location/search?location_tag_id=1&keywords=&order_by=rating&view=table');
         $this->assertEquals(200, $response->getStatusCode());
         $content = $response->getContent();
         $this->assertTrue(strpos($content, 'spreadsheet sort-by-rating') !== false);


### PR DESCRIPTION
The tests were broken after changes to location search showed the map by default.

This is related to pull request #653 and issue #651.